### PR TITLE
feat: add game controls and ghost behavior adjustments

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -39,6 +39,11 @@ function love.load()
 	recursiveEnumerate("rooms", room_files)
 	requireFiles(room_files)
 
+	WindowWidth, WindowHeight = love.graphics.getDimensions()
+
+	Control:bind("toggleDirection", "press space")
+	Control:bind("restart", "press r")
+
 	CurrentRoom = nil
 	gotoRoom("GameRoom")
 end
@@ -46,6 +51,9 @@ end
 function love.update(dt)
 	if CurrentRoom then
 		CurrentRoom:update(dt)
+	end
+	if Control.restart then
+		gotoRoom("GameRoom")
 	end
 	Lynput.update_(dt)
 end

--- a/objects/ghost.lua
+++ b/objects/ghost.lua
@@ -11,8 +11,13 @@ function Ghost:new(x, y, radius)
 	self.creation_time = love.timer.getTime()
 end
 
-function Ghost:update(dt)
+function Ghost:update(dt, pacmanX)
 	self.x = self.x + self.direction
+	if self.x < pacmanX then
+		self.direction = 1
+	elseif self.x > pacmanX then
+		self.direction = -1
+	end
 end
 
 function Ghost:draw()

--- a/objects/pacman.lua
+++ b/objects/pacman.lua
@@ -10,7 +10,15 @@ function Pacman:new(x, y, radius)
 end
 
 function Pacman:update(dt)
+	if Control.toggleDirection then
+		self.direction = self.direction == 1 and -1 or 1
+	end
 	self.x = self.x + self.direction
+	if self.x > WindowWidth then
+		self.x = 0
+	elseif self.x < 0 then
+		self.x = WindowWidth
+	end
 end
 
 function Pacman:draw()

--- a/rooms/game.lua
+++ b/rooms/game.lua
@@ -1,7 +1,7 @@
 GameRoom = Object:extend()
 
 function GameRoom:new()
-	self.tilesize = 48
+	self.tilesize = 49
 	self.tilemap = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 }
 	self.valid_power_idx = { 1, 2, 3, 4, 5, 12, 13, 14, 15, 16 }
 	self:spawnPower()
@@ -12,15 +12,30 @@ function GameRoom:new()
 	self.pacman = Pacman(self:getTileX(8), 100 + self.tilesize / 8, self.tilesize / 3)
 	self.ghost = Ghost(self:getTileX(16), 100 + self.tilesize / 8, self.tilesize / 3)
 
+	self.game_over = false
+	self.font = love.graphics.newFont(24)
+	self.font_color = { 255, 255, 255 }
 	self.creation_time = love.timer.getTime()
 end
 
 function GameRoom:update(dt)
+	if self.game_over then
+		return
+	end
+	if self.pacman.x == self.ghost.x then
+		self.game_over = true
+	end
 	self.pacman:update(dt)
-	self.ghost:update(dt)
+	self.ghost:update(dt, self.pacman.x)
 end
 
 function GameRoom:draw()
+	if self.game_over then
+		love.graphics.setFont(self.font)
+		love.graphics.setColor(love.math.colorFromBytes(unpack(self.point_color)))
+		love.graphics.print("You lost! Press R to try again.", 100, 200)
+	end
+
 	for i, tile in ipairs(self.tilemap) do
 		local x = self:getTileX(i)
 		local y = 100


### PR DESCRIPTION
- Added controls to toggle Pacman's direction and restart the game.
- Updated Ghost's movement to follow Pacman.
- Changed tile size in GameRoom from 48 to 49.
- Implemented game over condition when Pacman collides with Ghost.
- Displayed a game over message when the game ends.

closes #1 