### PR TITLE
fix: adjust Pacman's boundary checks and ghost collision detection

### DIFF
--- a/objects/pacman.lua
+++ b/objects/pacman.lua
@@ -13,11 +13,13 @@ function Pacman:update(dt)
 	if Control.toggleDirection then
 		self.direction = self.direction == 1 and -1 or 1
 	end
+
 	self.x = self.x + self.direction
-	if self.x > WindowWidth then
-		self.x = 0
-	elseif self.x < 0 then
-		self.x = WindowWidth
+
+	if self.x - self.radius > WindowWidth then
+		self.x = 0 - self.radius
+	elseif self.x + self.radius < 0 then
+		self.x = WindowWidth + self.radius
 	end
 end
 

--- a/rooms/game.lua
+++ b/rooms/game.lua
@@ -22,7 +22,7 @@ function GameRoom:update(dt)
 	if self.game_over then
 		return
 	end
-	if self.pacman.x == self.ghost.x then
+	if math.abs(self.pacman.x - self.ghost.x) <= 2 * (self.tilesize / 3) then
 		self.game_over = true
 	end
 	self.pacman:update(dt)


### PR DESCRIPTION
- Updated Pacman's boundary checks to account for its radius.
- Modified ghost collision detection to use a distance threshold based on tile size.

closes #4 