### PR TITLE
feat: adjust ghost speed and vulnerability duration

### DIFF
--- a/objects/ghost.lua
+++ b/objects/ghost.lua
@@ -5,7 +5,7 @@ function Ghost:new(x, y, radius, speed)
 	self.y = y
 	self.radius = radius
 
-	self.speed = speed + 0.5
+	self.speed = speed
 	self.direction = -1
 
 	self.vulnerable = false
@@ -19,7 +19,7 @@ function Ghost:new(x, y, radius, speed)
 	self.color = { 255, 0, 0 }
 	self.flash_color = { 255, 255, 255 }
 	self.vulnerable_color = { 0, 0, 255 }
-	self.dead_color = { 255, 0, 0, 100 }
+	self.dead_color = { 200, 200, 200, 50 }
 
 	self.timer = Timer()
 	self.creation_time = love.timer.getTime()
@@ -28,20 +28,24 @@ end
 function Ghost:update(dt, pacmanX)
 	local now = love.timer.getTime()
 	self.vulnerable = self.vulnerable_until and now < self.vulnerable_until
-	self.flash = self.vulnerable_until and self.vulnerable_until - now <= 1 and self.vulnerable_until - now > 0
+	self.flash = self.vulnerable_until and self.vulnerable_until - now <= 0.75 and self.vulnerable_until - now > 0
 
+	local effective_speed = self.speed
 	if self.dead then
-		if math.abs(self.x - self.go_to_point) < 1 then
+		effective_speed = self.speed * 1.2
+		if math.abs(self.x - self.go_to_point) < self.radius then
 			self.x = self.go_to_point
 			self.dead = false
 		else
 			self.direction = self.x < self.go_to_point and 1 or -1
-			self.x = self.x + (self.direction * self.speed)
+			self.x = self.x + (self.direction * effective_speed)
 		end
 	else
 		if not self.vulnerable then
+			effective_speed = self.speed * 1.1
 			self.direction = (self.x < pacmanX) and math.abs(self.direction) or -math.abs(self.direction)
 		else
+			effective_speed = self.speed * 0.7
 			self.direction = (self.x < pacmanX) and -math.abs(self.direction) or math.abs(self.direction)
 		end
 
@@ -50,7 +54,7 @@ function Ghost:update(dt, pacmanX)
 		elseif (self.x + self.direction) < self.radius then
 			self.x = self.radius
 		else
-			self.x = self.x + (self.direction * self.speed)
+			self.x = self.x + (self.direction * effective_speed)
 		end
 	end
 
@@ -81,7 +85,7 @@ function Ghost:makeVulnerable()
 	if self.vulnerable_until and self.vulnerable_until > now then
 		self.vulnerable_until = self.vulnerable_until + self.vulnerable_time
 	else
-		self.vulnerable_until = now + 3
+		self.vulnerable_until = now + 2
 	end
 end
 

--- a/rooms/game.lua
+++ b/rooms/game.lua
@@ -8,8 +8,8 @@ function GameRoom:new()
 	self.power_color = { 255, 255, 255 }
 	self.font_color = { 255, 255, 255 }
 
-	self.speed = 2
-	self.pacman = Pacman(self:getTileX(8), (WindowHeight / 2) + self.tilesize / 8, self.tilesize / 3, self.speed + 2)
+	self.speed = math.floor(self.tilesize / 10)
+	self.pacman = Pacman(self:getTileX(8), (WindowHeight / 2) + self.tilesize / 8, self.tilesize / 3, self.speed)
 	self.ghost = Ghost(self:getTileX(16), (WindowHeight / 2) + self.tilesize / 8, self.tilesize / 3, self.speed)
 	self.border_top = Border(0, (WindowHeight / 2) - self.tilesize / 2)
 	self.border_bot = Border(0, (WindowHeight / 2) + self.tilesize / 2 + 15)
@@ -66,7 +66,6 @@ function GameRoom:initMap()
 	self.tilemap = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 }
 	self.valid_power_idx = { 1, 2, 3, 4, 5, 12, 13, 14, 15, 16 }
 	self.remaining_points = #self.tilemap
-	self.remaining_points = 16
 	local idx = self.valid_power_idx[love.math.random(#self.valid_power_idx)]
 	self.tilemap[idx] = 2
 end


### PR DESCRIPTION
- Set ghost speed to be equal to the initial speed without increment.
- Change ghost dead color to a lighter shade.
- Update ghost vulnerability duration from 3 to 2 seconds.
- Modify effective speed calculations for ghost movement based on state.
- Adjust Pacman's speed calculation to be based on tile size.

closes #9 